### PR TITLE
Added support for Redis ACL

### DIFF
--- a/subprojects/spring-lettucemod/src/main/java/com/redis/spring/lettucemod/RedisModulesAutoConfiguration.java
+++ b/subprojects/spring-lettucemod/src/main/java/com/redis/spring/lettucemod/RedisModulesAutoConfiguration.java
@@ -28,6 +28,9 @@ public class RedisModulesAutoConfiguration {
 		if (properties.getPassword() != null) {
 			redisURI.setPassword(properties.getPassword().toCharArray());
 		}
+		if (properties.getUsername() != null) {
+			redisURI.setUsername(properties.getUsername());
+		}
 		Duration timeout = properties.getTimeout();
 		if (timeout != null) {
 			redisURI.setTimeout(timeout);


### PR DESCRIPTION
Added support for Redis ACL so username can be passed. Without it the connection is unsuccessful. The username is always set to default no matter what the user is passing